### PR TITLE
fix build and make test suite compatible with marshmallow 2 and 3

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,11 +46,3 @@ class UserSchema(Schema):
                               validate=validate.Length(min=1, max=3))
     github = fields.Nested(GithubProfile)
     const = fields.String(validate=validate.Length(equal=50))
-
-
-class BaseTest(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass


### PR DESCRIPTION
Looks like the issue ended up being future marshmallow 3 compatibility. With this patch, I can get the test suite to pass on both marshmallow v2 and v3